### PR TITLE
[BNG-126] TableOption Sort 컴포넌트 로직 수정

### DIFF
--- a/src/components/TableOption/Sort/SortModal.jsx
+++ b/src/components/TableOption/Sort/SortModal.jsx
@@ -53,11 +53,12 @@ function reducer(state, action) {
 export default function SortModal({ option, onSubmit, onClose, prevSortList }) {
   const [state, dispatch] = useReducer(reducer, prevSortList, init);
 
-  const valueOptions =
-    state.selectedKey &&
-    !state.sortList.some((sort) => sort.key === state.selectedKey)
-      ? option.values
-      : []; // 이미 정렬 방식이 지정된 key면 선택지 없음
+  // 이미 sortList에 있는 key는 제외
+  const keyOptions = option.keys.filter(
+    (key) => !state.sortList.some((sort) => sort.key === key),
+  );
+
+  const valueOptions = state.selectedKey ? option.values : [];
 
   return (
     <Modal onSubmit={() => onSubmit?.(state.sortList)} onClose={onClose}>
@@ -66,7 +67,7 @@ export default function SortModal({ option, onSubmit, onClose, prevSortList }) {
       <div className={styles.dropdownWrapper}>
         <Dropdown
           placeHolder="정렬 항목"
-          options={option.keys}
+          options={keyOptions}
           selectedValue={state.selectedKey}
           isOpen={state.isKeyOpen}
           onChange={(val) => dispatch({ type: 'SELECT_KEY', payload: val })}


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 수행한 작업 리스트를 작성해주세요. -->
- [x] TableOption의 정렬 컴포넌트에서 정렬 키를 선택하면 현재는 해당 키의 값들이 사라지는데 키가 사라지도록 수정.
- [x] SortModal.jsx 코드 수정.

## 🤔 중점적으로 봐야 할 부분
<!-- 리뷰어가 중점적으로 확인해야 할 부분이 있다면 작성해주세요. -->
- 정렬 옵션이 선택되면 해당 키가 사라지는지 확인 부탁드립니다.

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
- Resolved: #146 
