### PR TITLE
[BNG-200] ✨ Update stepper data before navigating next page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
       "node": true,
       "alias": {
         "map": [
+          ["#/*", "./src"],
           ["#components", "./src/components"],
           ["#pages", "./src/pages"],
           ["#styles", "./src/styles"],

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "#/*": ["./src/*"],
       "#components/*": ["src/components/*/index.js"],
       "#pages/*": ["./src/pages/*/index.js"],
       "#styles/*": ["./src/styles/*"],

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "webpack": "5.98.0"
   },
   "imports": {
+    "#/*": "./src/*",
     "#components/*": "./src/components/*",
     "#pages/*": "./src/pages/*",
     "#styles/*": "./src/styles/*",

--- a/src/components/Stepper/mockStepperApiResponse.js
+++ b/src/components/Stepper/mockStepperApiResponse.js
@@ -1,99 +1,17 @@
 export default {
-  1: {
-    기준설정: [
-      {
-        id: 'ANNUAL_CRITERIA_SUBJECT_000', // adj_info_step.id
-        text: '대상자 기준 설정',
-        state: 'UNDONE',
-        date: '2023-03-03 00:00:00',
-        url: 'annual/criteria/subject',
-      },
-      {
-        id: 'ANNUAL_CRITERIA_PAYMENT_RATE_000',
-        text: '보상지급률 설정',
-        state: 'UNDONE',
-        date: '2023-03-03 00:00:00',
-        url: 'annual/criteria/payment-rate',
-      },
-      {
-        id: 'ANNUAL_CRITERIA_PAYBAND_000',
-        text: 'Payband 설정',
-        state: 'UNDONE',
-        url: 'annual/criteria/payband',
-      },
-    ],
-    사전작업: [
-      {
-        id: 'ANNUAL_PRE_SUBJECT_000',
-        text: '대상자 편성',
-        state: 'UNDONE',
-        url: 'annual/preparation/subject',
-      },
-      {
-        id: 'ANNUAL_PRE_HIGH_PERFORMANCE_000',
-        text: '고성과조직 가산 대상 여부 설정',
-        state: 'UNDONE',
-        url: 'annual/preparation/high-performance',
-      },
-    ],
-    본연봉조정: [
-      {
-        id: 'ANNUAL_MAIN_PAYBAND_000',
-        text: 'Payband 적용',
-        state: 'UNDONE',
-        url: 'annual/main/payband',
-      },
-      {
-        id: 'ANNUAL_MAIN_RESULT_000',
-        text: '조정 결과 미리보기',
-        state: 'UNDONE',
-        url: 'annual/main/result',
-      },
-    ],
-  },
-  2: {
-    CRITERIA: [
-      {
-        id: 8,
-        text: '대상자 기준 설정',
-        state: 'UNDONE',
-      },
-      {
-        id: 9,
-        text: 'Base Up 설정',
-        state: 'UNDONE',
-      },
-    ],
-    MAIN: [
-      {
-        id: 10,
-        text: '조정 결과 확인',
-        state: 'UNDONE',
-      },
-    ],
-  },
-  3: {
-    CRITERIA: [
-      {
-        id: 11,
-        text: '승진 가산금 설정',
-        state: 'UNDONE',
-        date: '2023-03-03 00:00:00',
-      },
-    ],
-    PRE: [
-      {
-        id: 12,
-        text: '대상자 편성',
-        state: 'UNDONE',
-      },
-    ],
-    MAIN: [
-      {
-        id: 13,
-        text: '조정 결과 확인',
-        state: 'UNDONE',
-      },
-    ],
+  annual: {
+    criteria: {
+      subject: 'ANNUAL_CRITERIA_SUBJECT_000',
+      paymentRate: 'ANNUAL_CRITERIA_PAYMENT_RATE_000',
+      payband: 'ANNUAL_CRITERIA_PAYBAND_000',
+    },
+    preparation: {
+      subject: 'ANNUAL_PRE_SUBJECT_000',
+      highPerformance: 'ANNUAL_PRE_HIGH_PERFORMANCE_000',
+    },
+    main: {
+      payband: 'ANNUAL_MAIN_PAYBAND_000',
+      result: 'ANNUAL_MAIN_RESULT_000',
+    },
   },
 };

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,0 +1,19 @@
+export default {
+  step: {
+    annual: {
+      criteria: {
+        subject: 'ANNUAL_CRITERIA_SUBJECT_000',
+        paymentRate: 'ANNUAL_CRITERIA_PAYMENT_RATE_000',
+        payband: 'ANNUAL_CRITERIA_PAYBAND_000',
+      },
+      preparation: {
+        subject: 'ANNUAL_PRE_SUBJECT_000',
+        highPerformance: 'ANNUAL_PRE_HIGH_PERFORMANCE_000',
+      },
+      main: {
+        payband: 'ANNUAL_MAIN_PAYBAND_000',
+        result: 'ANNUAL_MAIN_RESULT_000',
+      },
+    },
+  },
+};

--- a/src/layouts/AdjustEditLayout/AdjustEditLayout.jsx
+++ b/src/layouts/AdjustEditLayout/AdjustEditLayout.jsx
@@ -40,7 +40,7 @@ export default function AdjustEditLayout({
         if (!res?.ok) {
           addError(
             `연봉조정 단계 정보 조회 실패 (${res.status} ${res.statusText})`,
-            `네트워크 상태 및 접근 경로의 연봉조정 ID(${adjust.adjustId}) 등이 유효한지 확인해 주시기 바랍니다.\n${json.message}`,
+            `네트워크 상태 및 접근 경로의 연봉조정 ID(${adjust.adjustId}) 등이 유효한지 확인해 주시기 바랍니다.\n${json.message ?? json.error}`,
             'ADJUST_STEP_FETCH_ERROR',
           );
 


### PR DESCRIPTION
## 변경 사항 안내
이제 다음 단계 버튼을 누르면 현재 단계가 완료된 것으로 간주합니다.
조정 단계 정보가 올바르게 업로드되지 않으면 다음 단계로 넘어가지지 않습니다.

## 공통 요청 사항
`#/constant`에서 다음과 같이 stepId를 받아올 수 있습니다.
```javascript
import constant from '#/constant';

const stepId = constants.step.annual.criteria.paymentRate
```
자신의 단계에 맞는 stepId를 받아서 다음과 같이 `AdjustEditLayout`에 Prop으로 넘겨주세요.
```javascript
<AdjustEditLayout
      ...
      stepId={constant.step.annual.criteria.subject}
>
...
```

## 페이지별 요청 사항
- `메인 페이지(조정 목록 페이지)`에서 정기연봉조정 생성 시, 다음 기본값 초기화를 수행해 주세요.
  - 기준일자 = 오늘 날짜
  - 대상제외일자 시작일 = 오늘 날짜
  - 대상제외일자 종료일 = 올해 12/31

## 관련 이슈
Resolved: #235 